### PR TITLE
Add enemy color change when damaged

### DIFF
--- a/script.js
+++ b/script.js
@@ -125,7 +125,15 @@ function spawnEnemy() {
             y = canvas.height + size;
             break;
     }
-    enemies.push({ x, y, size, speed: 1.5, hp: 2 });
+    enemies.push({
+        x,
+        y,
+        size,
+        speed: 1.5,
+        hp: 2,
+        maxHp: 2,
+        color: 'red'
+    });
 }
 
 function updatePlayer() {
@@ -200,6 +208,9 @@ function updateEnemies() {
             if (distB < b.radius + e.size) {
                 bullets.splice(bi, 1);
                 e.hp -= 1;
+                if (e.hp <= e.maxHp / 2) {
+                    e.color = 'orange';
+                }
                 if (e.hp <= 0) {
                     enemies.splice(i, 1);
                     spawnParticles(e.x, e.y, 15, 'orange');
@@ -236,8 +247,8 @@ function drawObstacles() {
 }
 
 function drawEnemies() {
-    ctx.fillStyle = 'red';
     enemies.forEach(e => {
+        ctx.fillStyle = e.color;
         ctx.beginPath();
         ctx.arc(e.x, e.y, e.size, 0, Math.PI * 2);
         ctx.fill();


### PR DESCRIPTION
## Summary
- enemies now track their max HP and current color
- change enemy color to orange when at or below half health

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853dc3069288323b998f963264bf909